### PR TITLE
fix: type error on deployParams

### DIFF
--- a/template_content/inject_content/AppCalls.tsx.jinja
+++ b/template_content/inject_content/AppCalls.tsx.jinja
@@ -57,7 +57,7 @@ const AppCalls = ({ openModal, setModalState }: AppCallsInterface) => {
     }
     {%- elif preset_name == 'production' %}
     const isLocal = await algokit.isLocalNet(algodClient)
-    const deployParams = {
+    const deployParams: Parameters<typeof appClient.deploy>[0] = {
       allowDelete: isLocal,
       allowUpdate: isLocal,
       onSchemaBreak: isLocal ? 'replace' : 'fail',

--- a/tests_generated/test_all_default_parameters_on_production/frontend/src/components/AppCalls.tsx
+++ b/tests_generated/test_all_default_parameters_on_production/frontend/src/components/AppCalls.tsx
@@ -51,7 +51,7 @@ const AppCalls = ({ openModal, setModalState }: AppCallsInterface) => {
     // Given the simplicity of the starter contract, we are deploying it on the frontend
     // for demonstration purposes.
     const isLocal = await algokit.isLocalNet(algodClient)
-    const deployParams = {
+    const deployParams: Parameters<typeof appClient.deploy>[0] = {
       allowDelete: isLocal,
       allowUpdate: isLocal,
       onSchemaBreak: isLocal ? 'replace' : 'fail',


### PR DESCRIPTION
onSchemaBreak and onUpdate values are being inferred as strings rather than constants when passed to the deploy method.

## Proposed Changes
This fix provide type info when creating `deployParams`.