### PR TITLE
Prep/simpler beta release

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -23,7 +23,8 @@ jobs:
         id: tag
         uses: TriPSs/conventional-changelog-action@v3.18.0
         with:
-          skip-commit: 'true'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          skip-commit: 'false'
           tag-prefix: ''
           skip-on-empty: 'false'
 

--- a/examples/p-py/projects/p-py-frontend/src/components/AppCalls.tsx
+++ b/examples/p-py/projects/p-py-frontend/src/components/AppCalls.tsx
@@ -5,6 +5,7 @@ import { HelloWorldFactory } from '../contracts/HelloWorld'
 import { OnSchemaBreak, OnUpdate } from '@algorandfoundation/algokit-utils/types/app'
 import { getAlgodConfigFromViteEnvironment, getIndexerConfigFromViteEnvironment } from '../utils/network/getAlgoClientConfigs'
 import { AlgorandClient } from '@algorandfoundation/algokit-utils'
+import { encodeTransactionRaw } from '@algorandfoundation/algokit-utils/transact'
 
 interface AppCallsInterface {
   openModal: boolean
@@ -15,7 +16,7 @@ const AppCalls = ({ openModal, setModalState }: AppCallsInterface) => {
   const [loading, setLoading] = useState<boolean>(false)
   const [contractInput, setContractInput] = useState<string>('')
   const { enqueueSnackbar } = useSnackbar()
-  const { transactionSigner, activeAddress } = useWallet()
+  const { signTransactions, activeAddress } = useWallet()
 
   const algodConfig = getAlgodConfigFromViteEnvironment()
   const indexerConfig = getIndexerConfigFromViteEnvironment()
@@ -23,7 +24,11 @@ const AppCalls = ({ openModal, setModalState }: AppCallsInterface) => {
     algodConfig,
     indexerConfig,
   })
-  algorand.setDefaultSigner(transactionSigner)
+  algorand.setDefaultSigner(async (txnGroup, indexesToSign) => {
+    const encoded = txnGroup.map((txn) => encodeTransactionRaw(txn))
+    const signed = await signTransactions(encoded, indexesToSign)
+    return signed.filter((s): s is Uint8Array => s !== null)
+  })
 
   const sendAppCall = async () => {
     setLoading(true)

--- a/examples/p-tls/projects/p-tls-frontend/src/components/AppCalls.tsx
+++ b/examples/p-tls/projects/p-tls-frontend/src/components/AppCalls.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { CalculatorFactory } from '../contracts/Calculator'
 import { getAlgodConfigFromViteEnvironment, getIndexerConfigFromViteEnvironment } from '../utils/network/getAlgoClientConfigs'
 import { AlgorandClient } from '@algorandfoundation/algokit-utils'
+import { encodeTransactionRaw } from '@algorandfoundation/algokit-utils/transact'
 
 interface AppCallsInterface {
   openModal: boolean
@@ -14,7 +15,7 @@ const AppCalls = ({ openModal, setModalState }: AppCallsInterface) => {
   const [loading, setLoading] = useState<boolean>(false)
   const [contractInput, setContractInput] = useState<string>('')
   const { enqueueSnackbar } = useSnackbar()
-  const { transactionSigner, activeAddress } = useWallet()
+  const { signTransactions, activeAddress } = useWallet()
 
   const algodConfig = getAlgodConfigFromViteEnvironment()
   const indexerConfig = getIndexerConfigFromViteEnvironment()
@@ -22,7 +23,11 @@ const AppCalls = ({ openModal, setModalState }: AppCallsInterface) => {
     algodConfig,
     indexerConfig,
   })
-  algorand.setDefaultSigner(transactionSigner)
+  algorand.setDefaultSigner(async (txnGroup, indexesToSign) => {
+    const encoded = txnGroup.map((txn) => encodeTransactionRaw(txn))
+    const signed = await signTransactions(encoded, indexesToSign)
+    return signed.filter((s): s is Uint8Array => s !== null)
+  })
 
   const sendAppCall = async () => {
     setLoading(true)

--- a/examples/p-ts/projects/p-ts-frontend/src/components/AppCalls.tsx
+++ b/examples/p-ts/projects/p-ts-frontend/src/components/AppCalls.tsx
@@ -5,6 +5,7 @@ import { HelloWorldFactory } from '../contracts/HelloWorld'
 import { OnSchemaBreak, OnUpdate } from '@algorandfoundation/algokit-utils/types/app'
 import { getAlgodConfigFromViteEnvironment, getIndexerConfigFromViteEnvironment } from '../utils/network/getAlgoClientConfigs'
 import { AlgorandClient } from '@algorandfoundation/algokit-utils'
+import { encodeTransactionRaw } from '@algorandfoundation/algokit-utils/transact'
 
 interface AppCallsInterface {
   openModal: boolean
@@ -15,7 +16,7 @@ const AppCalls = ({ openModal, setModalState }: AppCallsInterface) => {
   const [loading, setLoading] = useState<boolean>(false)
   const [contractInput, setContractInput] = useState<string>('')
   const { enqueueSnackbar } = useSnackbar()
-  const { transactionSigner, activeAddress } = useWallet()
+  const { signTransactions, activeAddress } = useWallet()
 
   const algodConfig = getAlgodConfigFromViteEnvironment()
   const indexerConfig = getIndexerConfigFromViteEnvironment()
@@ -23,7 +24,11 @@ const AppCalls = ({ openModal, setModalState }: AppCallsInterface) => {
     algodConfig,
     indexerConfig,
   })
-  algorand.setDefaultSigner(transactionSigner)
+  algorand.setDefaultSigner(async (txnGroup, indexesToSign) => {
+    const encoded = txnGroup.map((txn) => encodeTransactionRaw(txn))
+    const signed = await signTransactions(encoded, indexesToSign)
+    return signed.filter((s): s is Uint8Array => s !== null)
+  })
 
   const sendAppCall = async () => {
     setLoading(true)

--- a/examples/s-py/projects/s-py-frontend/src/components/AppCalls.tsx
+++ b/examples/s-py/projects/s-py-frontend/src/components/AppCalls.tsx
@@ -5,6 +5,7 @@ import { HelloWorldFactory } from '../contracts/HelloWorld'
 import { OnSchemaBreak, OnUpdate } from '@algorandfoundation/algokit-utils/types/app'
 import { getAlgodConfigFromViteEnvironment, getIndexerConfigFromViteEnvironment } from '../utils/network/getAlgoClientConfigs'
 import { AlgorandClient } from '@algorandfoundation/algokit-utils'
+import { encodeTransactionRaw } from '@algorandfoundation/algokit-utils/transact'
 
 interface AppCallsInterface {
   openModal: boolean
@@ -15,7 +16,7 @@ const AppCalls = ({ openModal, setModalState }: AppCallsInterface) => {
   const [loading, setLoading] = useState<boolean>(false)
   const [contractInput, setContractInput] = useState<string>('')
   const { enqueueSnackbar } = useSnackbar()
-  const { transactionSigner, activeAddress } = useWallet()
+  const { signTransactions, activeAddress } = useWallet()
 
   const algodConfig = getAlgodConfigFromViteEnvironment()
   const indexerConfig = getIndexerConfigFromViteEnvironment()
@@ -23,7 +24,11 @@ const AppCalls = ({ openModal, setModalState }: AppCallsInterface) => {
     algodConfig,
     indexerConfig,
   })
-  algorand.setDefaultSigner(transactionSigner)
+  algorand.setDefaultSigner(async (txnGroup, indexesToSign) => {
+    const encoded = txnGroup.map((txn) => encodeTransactionRaw(txn))
+    const signed = await signTransactions(encoded, indexesToSign)
+    return signed.filter((s): s is Uint8Array => s !== null)
+  })
 
   const sendAppCall = async () => {
     setLoading(true)

--- a/examples/s-tls/projects/s-tls-frontend/src/components/AppCalls.tsx
+++ b/examples/s-tls/projects/s-tls-frontend/src/components/AppCalls.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { CalculatorFactory } from '../contracts/Calculator'
 import { getAlgodConfigFromViteEnvironment, getIndexerConfigFromViteEnvironment } from '../utils/network/getAlgoClientConfigs'
 import { AlgorandClient } from '@algorandfoundation/algokit-utils'
+import { encodeTransactionRaw } from '@algorandfoundation/algokit-utils/transact'
 
 interface AppCallsInterface {
   openModal: boolean
@@ -14,7 +15,7 @@ const AppCalls = ({ openModal, setModalState }: AppCallsInterface) => {
   const [loading, setLoading] = useState<boolean>(false)
   const [contractInput, setContractInput] = useState<string>('')
   const { enqueueSnackbar } = useSnackbar()
-  const { transactionSigner, activeAddress } = useWallet()
+  const { signTransactions, activeAddress } = useWallet()
 
   const algodConfig = getAlgodConfigFromViteEnvironment()
   const indexerConfig = getIndexerConfigFromViteEnvironment()
@@ -22,7 +23,11 @@ const AppCalls = ({ openModal, setModalState }: AppCallsInterface) => {
     algodConfig,
     indexerConfig,
   })
-  algorand.setDefaultSigner(transactionSigner)
+  algorand.setDefaultSigner(async (txnGroup, indexesToSign) => {
+    const encoded = txnGroup.map((txn) => encodeTransactionRaw(txn))
+    const signed = await signTransactions(encoded, indexesToSign)
+    return signed.filter((s): s is Uint8Array => s !== null)
+  })
 
   const sendAppCall = async () => {
     setLoading(true)

--- a/examples/s-ts/projects/s-ts-frontend/src/components/AppCalls.tsx
+++ b/examples/s-ts/projects/s-ts-frontend/src/components/AppCalls.tsx
@@ -5,6 +5,7 @@ import { HelloWorldFactory } from '../contracts/HelloWorld'
 import { OnSchemaBreak, OnUpdate } from '@algorandfoundation/algokit-utils/types/app'
 import { getAlgodConfigFromViteEnvironment, getIndexerConfigFromViteEnvironment } from '../utils/network/getAlgoClientConfigs'
 import { AlgorandClient } from '@algorandfoundation/algokit-utils'
+import { encodeTransactionRaw } from '@algorandfoundation/algokit-utils/transact'
 
 interface AppCallsInterface {
   openModal: boolean
@@ -15,7 +16,7 @@ const AppCalls = ({ openModal, setModalState }: AppCallsInterface) => {
   const [loading, setLoading] = useState<boolean>(false)
   const [contractInput, setContractInput] = useState<string>('')
   const { enqueueSnackbar } = useSnackbar()
-  const { transactionSigner, activeAddress } = useWallet()
+  const { signTransactions, activeAddress } = useWallet()
 
   const algodConfig = getAlgodConfigFromViteEnvironment()
   const indexerConfig = getIndexerConfigFromViteEnvironment()
@@ -23,7 +24,11 @@ const AppCalls = ({ openModal, setModalState }: AppCallsInterface) => {
     algodConfig,
     indexerConfig,
   })
-  algorand.setDefaultSigner(transactionSigner)
+  algorand.setDefaultSigner(async (txnGroup, indexesToSign) => {
+    const encoded = txnGroup.map((txn) => encodeTransactionRaw(txn))
+    const signed = await signTransactions(encoded, indexesToSign)
+    return signed.filter((s): s is Uint8Array => s !== null)
+  })
 
   const sendAppCall = async () => {
     setLoading(true)

--- a/template_content/inject_content/AppCalls.tsx.jinja
+++ b/template_content/inject_content/AppCalls.tsx.jinja
@@ -9,6 +9,7 @@ import { OnSchemaBreak, OnUpdate } from '@algorandfoundation/algokit-utils/types
 {%- endif %}
 import { getAlgodConfigFromViteEnvironment, getIndexerConfigFromViteEnvironment } from '../utils/network/getAlgoClientConfigs'
 import { AlgorandClient } from '@algorandfoundation/algokit-utils'
+import { encodeTransactionRaw } from '@algorandfoundation/algokit-utils/transact'
 
 interface AppCallsInterface {
   openModal: boolean
@@ -19,7 +20,7 @@ const AppCalls = ({ openModal, setModalState }: AppCallsInterface) => {
   const [loading, setLoading] = useState<boolean>(false)
   const [contractInput, setContractInput] = useState<string>('')
   const { enqueueSnackbar } = useSnackbar()
-  const { transactionSigner, activeAddress } = useWallet()
+  const { signTransactions, activeAddress } = useWallet()
 
   const algodConfig = getAlgodConfigFromViteEnvironment()
   const indexerConfig = getIndexerConfigFromViteEnvironment()
@@ -27,7 +28,11 @@ const AppCalls = ({ openModal, setModalState }: AppCallsInterface) => {
     algodConfig,
     indexerConfig,
   })
-  algorand.setDefaultSigner(transactionSigner)
+  algorand.setDefaultSigner(async (txnGroup, indexesToSign) => {
+    const encoded = txnGroup.map((txn) => encodeTransactionRaw(txn))
+    const signed = await signTransactions(encoded, indexesToSign)
+    return signed.filter((s): s is Uint8Array => s !== null)
+  })
 
   const sendAppCall = async () => {
     setLoading(true)


### PR DESCRIPTION
## chore: prepare full-stack template for AlgoKit v4 beta

This PR builds on top of the decoupling branch to prepare the **full-stack template** for the **AlgoKit v4 beta** release. This simpler version specifically adds the changelog configuration and ensures the full-stack generator can correctly orchestrate child templates (frontend and contracts) currently sitting on `prep/beta-release` branches.

### Summary of Changes

* **Changelog Configuration:** Added the `conventional-changelog-action` to handle automated version tagging and release notes.
* **Cleanup:** Removed the unused `pull_request_template.md` and updated examples for ESM/NodeNext standards.

### Integration Strategy

I ran the tests using the specific branch references for the new `algokit-python-templates`, `algokit-typescript-template`, and `algokit-react-template` branches I prepared with the correct alpha dependencies.

**Note on local testing:** I had some trouble updating local templates because the environment kept defaulting to the production templates in the AlgoKit CLI. Because I've already deeply tested the logic using the referenced branches, this PR assumes that once these generators are pushed to production in the CLI, the full-stack template will work perfectly as it uses those templates that were already validated.

---

### Important

**Status: Draft**
This PR is a draft while we finish beta alignment across the sub-repos. Once the betas are official, I'll do a final pass on the example versions and the default refs.